### PR TITLE
Reimplement PCP instance domain handling for Choice meters

### DIFF
--- a/DiskUsageMeter.c
+++ b/DiskUsageMeter.c
@@ -1,0 +1,129 @@
+/*
+htop - DiskUsageMeter.c
+(C) 2021 htop dev team
+Released under the GNU GPL, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "DiskUsageMeter.h"
+
+#include <math.h>
+
+#include "CRT.h"
+#include "Platform.h"
+
+
+const DiskUsageData invalidDiskUsageData = { NAN, NAN, NAN };
+
+typedef struct DiskUsageMeterData_ {
+   DiskUsageData data;
+   char* choice;
+   time_t last_updated;
+} DiskUsageMeterData;
+
+static const int DiskUsageMeter_attributes[] = {
+   METER_VALUE,
+};
+
+static void DiskUsageMeter_init(Meter* this) {
+   if (!this->meterData)
+      this->meterData = xCalloc(1, sizeof(DiskUsageMeterData));
+}
+
+static void DiskUsageMeter_done(Meter* this) {
+   DiskUsageMeterData* mdata = this->meterData;
+   if (!mdata)
+      return;
+
+   free(mdata->choice);
+   free(mdata);
+}
+
+static void DiskUsageMeter_updateValues(Meter* this) {
+   DiskUsageMeterData* mdata = this->meterData;
+
+   /* update only every 30s */
+   if (this->pl->realtime.tv_sec - mdata->last_updated > 30 || !mdata->choice || (this->curChoice && !String_eq(mdata->choice, this->curChoice))) {
+      free(mdata->choice);
+      mdata->choice = this->curChoice ? xStrdup(this->curChoice) : NULL;
+      mdata->last_updated = this->pl->realtime.tv_sec;
+
+      if (this->curChoice)
+         Platform_getDiskUsage(this->curChoice, &mdata->data);
+   }
+
+   this->values[0] = isInvalidDiskUsageData(&mdata->data) ? NAN : mdata->data.usedPercentage;
+
+   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%s - %.1f%%", this->curChoice ? this->curChoice : "N/A", this->values[0]);
+}
+
+static int printBytes(char* buffer, size_t size, double bytes) {
+   if (bytes < ONE_DECIMAL_K)
+      return xSnprintf(buffer, size, "%.0fB", bytes);
+   if (bytes < ONE_DECIMAL_M)
+      return xSnprintf(buffer, size, "%.1fKB", bytes / ONE_DECIMAL_K);
+   if (bytes < ONE_DECIMAL_G)
+      return xSnprintf(buffer, size, "%.1fMB", bytes / ONE_DECIMAL_M);
+   if (bytes < ONE_DECIMAL_T)
+      return xSnprintf(buffer, size, "%.1fGB", bytes / ONE_DECIMAL_G);
+   if (bytes < ONE_DECIMAL_P)
+      return xSnprintf(buffer, size, "%.1fTB", bytes / ONE_DECIMAL_T);
+
+   return xSnprintf(buffer, size, "%.0fPB", bytes / ONE_DECIMAL_P);
+}
+
+static void DiskUsageMeter_display(const Object* cast, RichString* out) {
+   const Meter* this = (const Meter*) cast;
+   DiskUsageMeterData* mdata = this->meterData;
+
+   if (!this->curChoice) {
+      RichString_appendAscii(out, CRT_colors[METER_VALUE_ERROR], "Invalid choice");
+      return;
+   } else if (isInvalidDiskUsageData(&mdata->data)) {
+      RichString_appendAscii(out, CRT_colors[METER_VALUE_ERROR], "Invalid data for ");
+      RichString_appendAscii(out, CRT_colors[METER_VALUE_ERROR], this->curChoice);
+      return;
+   }
+
+   char buffer[16];
+   int len;
+   int color = mdata->data.usedPercentage >= 85 ? CRT_colors[METER_VALUE_NOTICE] : CRT_colors[METER_VALUE];
+
+   len = RichString_appendAscii(out, CRT_colors[METER_VALUE], mdata->choice);
+   if (len < 15)
+      RichString_appendChr(out, CRT_colors[METER_TEXT], ' ', 15 - len);
+
+   len = xSnprintf(buffer, sizeof(buffer), " %4.1f%%", mdata->data.usedPercentage);
+   RichString_appendnAscii(out, color, buffer, len);
+
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " (");
+
+   len = printBytes(buffer, sizeof(buffer), mdata->data.used);
+   RichString_appendnAscii(out, CRT_colors[METER_VALUE], buffer, len);
+
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], "/");
+
+   len = printBytes(buffer, sizeof(buffer), mdata->data.total);
+   RichString_appendnAscii(out, CRT_colors[METER_VALUE], buffer, len);
+
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], ")");
+}
+
+const MeterClass DiskUsageMeter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete,
+      .display = DiskUsageMeter_display
+   },
+   .updateValues = DiskUsageMeter_updateValues,
+   .defaultMode = TEXT_METERMODE,
+   .maxItems = 1,
+   .total = 100.0,
+   .attributes = DiskUsageMeter_attributes,
+   .name = "DiskUsage",
+   .uiName = "Disk Usage",
+   .caption = "Disk: ",
+   .init = DiskUsageMeter_init,
+   .done = DiskUsageMeter_done,
+   .getChoices = Platform_getDiskUsageChoices,
+};

--- a/DiskUsageMeter.h
+++ b/DiskUsageMeter.h
@@ -1,0 +1,30 @@
+#ifndef HEADER_DiskUsage
+#define HEADER_DiskUsage
+/*
+htop - DiskUsageMeter.h
+(C) 2021 htop dev team
+Released under the GNU GPL, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "Meter.h"
+
+#include <math.h>
+
+
+typedef struct DiskUsageData_ {
+   double total;           /* total disk size in bytes */
+   double used;            /* used disk space in bytes */
+   double usedPercentage;  /* used disk amount in percent */
+} DiskUsageData;
+
+extern const DiskUsageData invalidDiskUsageData;
+
+static inline bool isInvalidDiskUsageData(const DiskUsageData *data)
+{
+   return isnan(data->total);
+}
+
+extern const MeterClass DiskUsageMeter_class;
+
+#endif

--- a/DynamicMeter.c
+++ b/DynamicMeter.c
@@ -84,6 +84,7 @@ static void DynamicMeter_updateValues(Meter* meter) {
 
 static void DynamicMeter_display(const Object* cast, RichString* out) {
    const Meter* meter = (const Meter*)cast;
+
    Platform_dynamicMeterDisplay(meter, out);
 }
 
@@ -128,4 +129,5 @@ const MeterClass DynamicMeter_class = {
    .name = "Dynamic",
    .uiName = "Dynamic",
    .caption = "",
+   .getChoices = Platform_getDynamicMeterChoices,
 };

--- a/HostnameMeter.c
+++ b/HostnameMeter.c
@@ -9,10 +9,17 @@ in the source distribution for its full text.
 
 #include "HostnameMeter.h"
 
+#include <netinet/in.h>
+
 #include "CRT.h"
 #include "Object.h"
 #include "Platform.h"
+#include "XUtils.h"
 
+
+#ifndef HOST_NAME_MAX
+#define HOST_NAME_MAX 256
+#endif
 
 static const int HostnameMeter_attributes[] = {
    HOSTNAME
@@ -20,6 +27,34 @@ static const int HostnameMeter_attributes[] = {
 
 static void HostnameMeter_updateValues(Meter* this) {
    Platform_getHostname(this->txtBuffer, sizeof(this->txtBuffer));
+}
+
+static void HostnameIPv4Meter_updateValues(Meter* this) {
+   char hostnameBuffer[HOST_NAME_MAX];
+   Platform_getHostname(hostnameBuffer, sizeof(hostnameBuffer));
+
+   if (!this->curChoice) {
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%s (invalid choice)", hostnameBuffer);
+   } else {
+      char ipv4[INET_ADDRSTRLEN];
+      Platform_getLocalIPv4address(this->curChoice, ipv4, sizeof(ipv4));
+
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%s (%s @ %s)", hostnameBuffer, ipv4, this->curChoice);
+   }
+}
+
+static void HostnameIPv6Meter_updateValues(ATTR_UNUSED Meter* this) {
+   char hostnameBuffer[HOST_NAME_MAX];
+   Platform_getHostname(hostnameBuffer, sizeof(hostnameBuffer));
+
+   if (!this->curChoice) {
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%s (invalid choice)", hostnameBuffer);
+   } else {
+      char ipv6[INET6_ADDRSTRLEN];
+      Platform_getLocalIPv6address(this->curChoice, ipv6, sizeof(ipv6));
+
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%s (%s @ %s)", hostnameBuffer, ipv6, this->curChoice);
+   }
 }
 
 const MeterClass HostnameMeter_class = {
@@ -35,4 +70,38 @@ const MeterClass HostnameMeter_class = {
    .name = "Hostname",
    .uiName = "Hostname",
    .caption = "Hostname: ",
+};
+
+const MeterClass HostnameIPv4Meter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete
+   },
+   .updateValues = HostnameIPv4Meter_updateValues,
+   .defaultMode = TEXT_METERMODE,
+   .maxItems = 0,
+   .total = 100.0,
+   .attributes = HostnameMeter_attributes,
+   .name = "HostnameIPv4",
+   .uiName = "HostnameIPv4",
+   .description = "Hostname with link-local IPv4 address",
+   .caption = "Hostname: ",
+   .getChoices = Platform_getLocalIPv4addressChoices,
+};
+
+const MeterClass HostnameIPv6Meter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete
+   },
+   .updateValues = HostnameIPv6Meter_updateValues,
+   .defaultMode = TEXT_METERMODE,
+   .maxItems = 0,
+   .total = 100.0,
+   .attributes = HostnameMeter_attributes,
+   .name = "HostnameIPv6",
+   .uiName = "HostnameIPv6",
+   .description = "Hostname with link-local IPv6 address",
+   .caption = "Hostname: ",
+   .getChoices = Platform_getLocalIPv6addressChoices,
 };

--- a/HostnameMeter.h
+++ b/HostnameMeter.h
@@ -12,4 +12,8 @@ in the source distribution for its full text.
 
 extern const MeterClass HostnameMeter_class;
 
+extern const MeterClass HostnameIPv4Meter_class;
+
+extern const MeterClass HostnameIPv6Meter_class;
+
 #endif

--- a/Macros.h
+++ b/Macros.h
@@ -82,4 +82,16 @@ static inline unsigned long long saturatingSub(unsigned long long a, unsigned lo
    return a > b ? a - b : 0;
 }
 
+#define ONE_K 1024UL
+#define ONE_M (ONE_K * ONE_K)
+#define ONE_G (ONE_M * ONE_K)
+#define ONE_T (1ULL * ONE_G * ONE_K)
+#define ONE_P (1ULL * ONE_T * ONE_K)
+
+#define ONE_DECIMAL_K 1000UL
+#define ONE_DECIMAL_M (ONE_DECIMAL_K * ONE_DECIMAL_K)
+#define ONE_DECIMAL_G (ONE_DECIMAL_M * ONE_DECIMAL_K)
+#define ONE_DECIMAL_T (1ULL * ONE_DECIMAL_G * ONE_DECIMAL_K)
+#define ONE_DECIMAL_P (1ULL * ONE_DECIMAL_T * ONE_DECIMAL_K)
+
 #endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -162,6 +162,7 @@ linux_platform_headers = \
 	linux/IOPriority.h \
 	linux/IOPriorityPanel.h \
 	linux/LibSensors.h \
+	linux/LibSensorsFanMeter.h \
 	linux/LibSensorsTempMeter.h \
 	linux/LinuxProcess.h \
 	linux/LinuxProcessList.h \
@@ -184,6 +185,7 @@ linux_platform_sources = \
 	linux/HugePageMeter.c \
 	linux/IOPriorityPanel.c \
 	linux/LibSensors.c \
+	linux/LibSensorsFanMeter.c \
 	linux/LibSensorsTempMeter.c \
 	linux/LinuxProcess.c \
 	linux/LinuxProcessList.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -162,6 +162,7 @@ linux_platform_headers = \
 	linux/IOPriority.h \
 	linux/IOPriorityPanel.h \
 	linux/LibSensors.h \
+	linux/LibSensorsTempMeter.h \
 	linux/LinuxProcess.h \
 	linux/LinuxProcessList.h \
 	linux/Platform.h \
@@ -183,6 +184,7 @@ linux_platform_sources = \
 	linux/HugePageMeter.c \
 	linux/IOPriorityPanel.c \
 	linux/LibSensors.c \
+	linux/LibSensorsTempMeter.c \
 	linux/LinuxProcess.c \
 	linux/LinuxProcessList.c \
 	linux/Platform.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -46,6 +46,7 @@ myhtopsources = \
 	DateMeter.c \
 	DateTimeMeter.c \
 	DiskIOMeter.c \
+	DiskUsageMeter.c \
 	DisplayOptionsPanel.c \
 	DynamicColumn.c \
 	DynamicMeter.c \
@@ -105,6 +106,7 @@ myhtopheaders = \
 	DateMeter.h \
 	DateTimeMeter.h \
 	DiskIOMeter.h \
+	DiskUsageMeter.h \
 	DisplayOptionsPanel.h \
 	DynamicColumn.h \
 	DynamicMeter.h \

--- a/Meter.h
+++ b/Meter.h
@@ -56,7 +56,7 @@ typedef void(*Meter_UpdateValues)(Meter*);
 typedef void(*Meter_Draw)(Meter*, int, int, int);
 typedef const char* (*Meter_GetCaption)(const Meter*);
 typedef void(*Meter_GetUiName)(const Meter*, char*, size_t);
-typedef char**(*Meter_GetChoices)(void);
+typedef char**(*Meter_GetChoices)(Meter*);
 
 typedef struct MeterClass_ {
    const ObjectClass super;
@@ -98,7 +98,7 @@ typedef struct MeterClass_ {
 #define Meter_uiName(this_)            As_Meter(this_)->uiName
 #define Meter_isMultiColumn(this_)     As_Meter(this_)->isMultiColumn
 #define Meter_getChoicesFn(this_)      As_Meter(this_)->getChoices
-#define Meter_getChoices(this_)        (assert(As_Meter(this_)->getChoices), As_Meter(this_)->getChoices())
+#define Meter_getChoices(this_)        (assert(As_Meter(this_)->getChoices), As_Meter(this_)->getChoices((Meter*)(this_)))
 
 typedef struct GraphData_ {
    struct timeval time;

--- a/Meter.h
+++ b/Meter.h
@@ -56,6 +56,7 @@ typedef void(*Meter_UpdateValues)(Meter*);
 typedef void(*Meter_Draw)(Meter*, int, int, int);
 typedef const char* (*Meter_GetCaption)(const Meter*);
 typedef void(*Meter_GetUiName)(const Meter*, char*, size_t);
+typedef char**(*Meter_GetChoices)(void);
 
 typedef struct MeterClass_ {
    const ObjectClass super;
@@ -66,6 +67,7 @@ typedef struct MeterClass_ {
    const Meter_Draw draw;
    const Meter_GetCaption getCaption;
    const Meter_GetUiName getUiName;
+   const Meter_GetChoices getChoices;
    const int defaultMode;
    const double total;
    const int* const attributes;
@@ -95,6 +97,8 @@ typedef struct MeterClass_ {
 #define Meter_name(this_)              As_Meter(this_)->name
 #define Meter_uiName(this_)            As_Meter(this_)->uiName
 #define Meter_isMultiColumn(this_)     As_Meter(this_)->isMultiColumn
+#define Meter_getChoicesFn(this_)      As_Meter(this_)->getChoices
+#define Meter_getChoices(this_)        (assert(As_Meter(this_)->getChoices), As_Meter(this_)->getChoices())
 
 typedef struct GraphData_ {
    struct timeval time;
@@ -117,6 +121,7 @@ struct Meter_ {
    char txtBuffer[METER_TXTBUFFER_LEN];
    double* values;
    double total;
+   char* curChoice;           /*<< selected choice, can be NULL on invalid choice */
    void* meterData;
 };
 
@@ -153,6 +158,10 @@ void Meter_delete(Object* cast);
 void Meter_setCaption(Meter* this, const char* caption);
 
 void Meter_setMode(Meter* this, int modeIndex);
+
+void Meter_setChoice(Meter* this, const char* choice);
+
+void Meter_nextChoice(Meter* this);
 
 ListItem* Meter_toListItem(const Meter* this, bool moving);
 

--- a/Meter.h
+++ b/Meter.h
@@ -9,6 +9,7 @@ in the source distribution for its full text.
 
 #include "config.h" // IWYU pragma: keep
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -78,15 +79,15 @@ typedef struct MeterClass_ {
 
 #define As_Meter(this_)                ((const MeterClass*)((this_)->super.klass))
 #define Meter_initFn(this_)            As_Meter(this_)->init
-#define Meter_init(this_)              As_Meter(this_)->init((Meter*)(this_))
-#define Meter_done(this_)              As_Meter(this_)->done((Meter*)(this_))
+#define Meter_init(this_)              (assert(As_Meter(this_)->init), As_Meter(this_)->init((Meter*)(this_)))
+#define Meter_done(this_)              (assert(As_Meter(this_)->done), As_Meter(this_)->done((Meter*)(this_)))
 #define Meter_updateModeFn(this_)      As_Meter(this_)->updateMode
-#define Meter_updateMode(this_, m_)    As_Meter(this_)->updateMode((Meter*)(this_), m_)
+#define Meter_updateMode(this_, m_)    (assert(As_Meter(this_)->updateMode), As_Meter(this_)->updateMode((Meter*)(this_), m_))
 #define Meter_drawFn(this_)            As_Meter(this_)->draw
 #define Meter_doneFn(this_)            As_Meter(this_)->done
-#define Meter_updateValues(this_)      As_Meter(this_)->updateValues((Meter*)(this_))
+#define Meter_updateValues(this_)      (assert(As_Meter(this_)->updateValues), As_Meter(this_)->updateValues((Meter*)(this_)))
 #define Meter_getUiNameFn(this_)       As_Meter(this_)->getUiName
-#define Meter_getUiName(this_,n_,l_)   As_Meter(this_)->getUiName((const Meter*)(this_),n_,l_)
+#define Meter_getUiName(this_,n_,l_)   (assert(As_Meter(this_)->getUiName), As_Meter(this_)->getUiName((const Meter*)(this_),n_,l_))
 #define Meter_getCaptionFn(this_)      As_Meter(this_)->getCaption
 #define Meter_getCaption(this_)        (Meter_getCaptionFn(this_) ? As_Meter(this_)->getCaption((const Meter*)(this_)) : (this_)->caption)
 #define Meter_defaultMode(this_)       As_Meter(this_)->defaultMode

--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -14,109 +14,124 @@
 #include "XUtils.h"
 
 
+typedef struct NetworkIOMeterData_ {
+   uint64_t last_update;
+   uint64_t rxb_total;
+   uint64_t rxp_total;
+   uint64_t txb_total;
+   uint64_t txp_total;
+   uint32_t rxb_diff;
+   uint32_t rxp_diff;
+   uint32_t txb_diff;
+   uint32_t txp_diff;
+   MeterRateStatus status;
+} NetworkIOMeterData;
+
 static const int NetworkIOMeter_attributes[] = {
    METER_VALUE_IOREAD,
    METER_VALUE_IOWRITE,
 };
 
-static MeterRateStatus status = RATESTATUS_INIT;
-static uint32_t cached_rxb_diff;
-static uint32_t cached_rxp_diff;
-static uint32_t cached_txb_diff;
-static uint32_t cached_txp_diff;
+static void NetworkIOMeter_init(Meter* this) {
+   if (!this->meterData)
+      this->meterData = xCalloc(1, sizeof(NetworkIOMeterData));
+}
+
+static void NetworkIOMeter_done(Meter* this) {
+   free(this->meterData);
+}
 
 static void NetworkIOMeter_updateValues(Meter* this) {
    const ProcessList* pl = this->pl;
-   static uint64_t cached_last_update = 0;
+   NetworkIOMeterData* mdata = this->meterData;
 
-   uint64_t passedTimeInMs = pl->realtimeMs - cached_last_update;
+   uint64_t passedTimeInMs = pl->realtimeMs - mdata->last_update;
 
    /* update only every 500ms to have a sane span for rate calculation */
    if (passedTimeInMs > 500) {
-      static uint64_t cached_rxb_total;
-      static uint64_t cached_rxp_total;
-      static uint64_t cached_txb_total;
-      static uint64_t cached_txp_total;
       uint64_t diff;
 
       NetworkIOData data;
       if (!Platform_getNetworkIO(&data)) {
-         status = RATESTATUS_NODATA;
-      } else if (cached_last_update == 0) {
-         status = RATESTATUS_INIT;
+         mdata->status = RATESTATUS_NODATA;
+      } else if (mdata->last_update == 0) {
+         mdata->status = RATESTATUS_INIT;
       } else if (passedTimeInMs > 30000) {
-         status = RATESTATUS_STALE;
+         mdata->status = RATESTATUS_STALE;
       } else {
-         status = RATESTATUS_DATA;
+         mdata->status = RATESTATUS_DATA;
       }
 
-      cached_last_update = pl->realtimeMs;
+      mdata->last_update = pl->realtimeMs;
 
-      if (status == RATESTATUS_NODATA) {
+      if (mdata->status == RATESTATUS_NODATA) {
          xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "no data");
          return;
       }
 
-      if (data.bytesReceived > cached_rxb_total) {
-         diff = data.bytesReceived - cached_rxb_total;
+      if (data.bytesReceived > mdata->rxb_total) {
+         diff = data.bytesReceived - mdata->rxb_total;
          diff /= ONE_K; /* Meter_humanUnit() expects unit in kilo */
          diff = (1000 * diff) / passedTimeInMs; /* convert to per second */
-         cached_rxb_diff = (uint32_t)diff;
+         mdata->rxb_diff = (uint32_t)diff;
       } else {
-         cached_rxb_diff = 0;
+         mdata->rxb_diff = 0;
       }
-      cached_rxb_total = data.bytesReceived;
+      mdata->rxb_total = data.bytesReceived;
 
-      if (data.packetsReceived > cached_rxp_total) {
-         diff = data.packetsReceived - cached_rxp_total;
-         cached_rxp_diff = (uint32_t)diff;
+      if (data.packetsReceived > mdata->rxp_total) {
+         diff = data.packetsReceived - mdata->rxp_total;
+         mdata->rxp_diff = (uint32_t)diff;
       } else {
-         cached_rxp_diff = 0;
+         mdata->rxp_diff = 0;
       }
-      cached_rxp_total = data.packetsReceived;
+      mdata->rxp_total = data.packetsReceived;
 
-      if (data.bytesTransmitted > cached_txb_total) {
-         diff = data.bytesTransmitted - cached_txb_total;
+      if (data.bytesTransmitted > mdata->txb_total) {
+         diff = data.bytesTransmitted - mdata->txb_total;
          diff /= ONE_K; /* Meter_humanUnit() expects unit in kilo */
          diff = (1000 * diff) / passedTimeInMs; /* convert to per second */
-         cached_txb_diff = (uint32_t)diff;
+         mdata->txb_diff = (uint32_t)diff;
       } else {
-         cached_txb_diff = 0;
+         mdata->txb_diff = 0;
       }
-      cached_txb_total = data.bytesTransmitted;
+      mdata->txb_total = data.bytesTransmitted;
 
-      if (data.packetsTransmitted > cached_txp_total) {
-         diff = data.packetsTransmitted - cached_txp_total;
-         cached_txp_diff = (uint32_t)diff;
+      if (data.packetsTransmitted > mdata->txp_total) {
+         diff = data.packetsTransmitted - mdata->txp_total;
+         mdata->txp_diff = (uint32_t)diff;
       } else {
-         cached_txp_diff = 0;
+         mdata->txp_diff = 0;
       }
-      cached_txp_total = data.packetsTransmitted;
+      mdata->txp_total = data.packetsTransmitted;
    }
 
-   if (status == RATESTATUS_INIT) {
+   if (mdata->status == RATESTATUS_INIT) {
       xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "init");
       return;
    }
-   if (status == RATESTATUS_STALE) {
+   if (mdata->status == RATESTATUS_STALE) {
       xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "stale");
       return;
    }
 
-   this->values[0] = cached_rxb_diff;
-   this->values[1] = cached_txb_diff;
-   if (cached_rxb_diff + cached_txb_diff > this->total) {
-      this->total = cached_rxb_diff + cached_txb_diff;
+   this->values[0] = mdata->rxb_diff;
+   this->values[1] = mdata->txb_diff;
+   if (this->values[0] + this->values[1] > this->total) {
+      this->total = this->values[0] + this->values[1];
    }
 
    char bufferBytesReceived[12], bufferBytesTransmitted[12];
-   Meter_humanUnit(bufferBytesReceived, cached_rxb_diff, sizeof(bufferBytesReceived));
-   Meter_humanUnit(bufferBytesTransmitted, cached_txb_diff, sizeof(bufferBytesTransmitted));
+   Meter_humanUnit(bufferBytesReceived, mdata->rxb_diff, sizeof(bufferBytesReceived));
+   Meter_humanUnit(bufferBytesTransmitted, mdata->txb_diff, sizeof(bufferBytesTransmitted));
    xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "rx:%siB/s tx:%siB/s", bufferBytesReceived, bufferBytesTransmitted);
 }
 
-static void NetworkIOMeter_display(ATTR_UNUSED const Object* cast, RichString* out) {
-   switch (status) {
+static void NetworkIOMeter_display(const Object* cast, RichString* out) {
+   const Meter* this = (const Meter *)cast;
+   const NetworkIOMeterData* mdata = this->meterData;
+
+   switch (mdata->status) {
    case RATESTATUS_NODATA:
       RichString_writeAscii(out, CRT_colors[METER_VALUE_ERROR], "no data");
       return;
@@ -134,16 +149,16 @@ static void NetworkIOMeter_display(ATTR_UNUSED const Object* cast, RichString* o
    int len;
 
    RichString_writeAscii(out, CRT_colors[METER_TEXT], "rx: ");
-   Meter_humanUnit(buffer, cached_rxb_diff, sizeof(buffer));
+   Meter_humanUnit(buffer, mdata->rxb_diff, sizeof(buffer));
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOREAD], buffer);
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOREAD], "iB/s");
 
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " tx: ");
-   Meter_humanUnit(buffer, cached_txb_diff, sizeof(buffer));
+   Meter_humanUnit(buffer, mdata->txb_diff, sizeof(buffer));
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], buffer);
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], "iB/s");
 
-   len = xSnprintf(buffer, sizeof(buffer), " (%u/%u packets) ", cached_rxp_diff, cached_txp_diff);
+   len = xSnprintf(buffer, sizeof(buffer), " (%u/%u packets) ", mdata->rxp_diff, mdata->txp_diff);
    RichString_appendnAscii(out, CRT_colors[METER_TEXT], buffer, len);
 }
 
@@ -160,5 +175,7 @@ const MeterClass NetworkIOMeter_class = {
    .attributes = NetworkIOMeter_attributes,
    .name = "NetworkIO",
    .uiName = "Network IO",
-   .caption = "Network: "
+   .caption = "Network: ",
+   .init = NetworkIOMeter_init,
+   .done = NetworkIOMeter_done,
 };

--- a/NetworkIOMeter.h
+++ b/NetworkIOMeter.h
@@ -12,5 +12,6 @@ typedef struct NetworkIOData_ {
 } NetworkIOData;
 
 extern const MeterClass NetworkIOMeter_class;
+extern const MeterClass NetworkInterfaceIOMeter_class;
 
 #endif /* HEADER_NetworkIOMeter */

--- a/Panel.c
+++ b/Panel.c
@@ -71,7 +71,8 @@ void Panel_done(Panel* this) {
    assert (this != NULL);
    free(this->eventHandlerState);
    Vector_delete(this->items);
-   FunctionBar_delete(this->defaultBar);
+   if (this->defaultBar)
+      FunctionBar_delete(this->defaultBar);
    RichString_delete(&this->header);
 }
 

--- a/Process.h
+++ b/Process.h
@@ -329,18 +329,6 @@ static inline bool Process_isThread(const Process* this) {
 #define CMDLINE_HIGHLIGHT_FLAG_COMM       0x00000004
 #define CMDLINE_HIGHLIGHT_FLAG_DELETED    0x00000008
 
-#define ONE_K 1024UL
-#define ONE_M (ONE_K * ONE_K)
-#define ONE_G (ONE_M * ONE_K)
-#define ONE_T (1ULL * ONE_G * ONE_K)
-#define ONE_P (1ULL * ONE_T * ONE_K)
-
-#define ONE_DECIMAL_K 1000UL
-#define ONE_DECIMAL_M (ONE_DECIMAL_K * ONE_DECIMAL_K)
-#define ONE_DECIMAL_G (ONE_DECIMAL_M * ONE_DECIMAL_K)
-#define ONE_DECIMAL_T (1ULL * ONE_DECIMAL_G * ONE_DECIMAL_K)
-#define ONE_DECIMAL_P (1ULL * ONE_DECIMAL_T * ONE_DECIMAL_K)
-
 void Process_setupColumnWidths(void);
 
 /* Sets the size of the UID column based on the passed UID */

--- a/Settings.h
+++ b/Settings.h
@@ -31,6 +31,7 @@ typedef struct {
    size_t len;
    char** names;
    int* modes;
+   char** choices;
 } MeterColumnSetting;
 
 typedef struct {

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -443,13 +443,15 @@ void Platform_gettime_monotonic(uint64_t* msec) {
 
 }
 
-char** Platform_getLocalIPv4addressChoices(void) {
+char** Platform_getLocalIPv4addressChoices(Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
-char** Platform_getLocalIPv6addressChoices(void) {
+char** Platform_getLocalIPv6addressChoices(Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
@@ -469,8 +471,9 @@ void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size)
    return;
 }
 
-char **Platform_getDiskUsageChoices(void) {
+char **Platform_getDiskUsageChoices(Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
@@ -478,4 +481,10 @@ void Platform_getDiskUsage(const char* choice, DiskUsageData *data) {
    // TODO
    (void) choice;
    (void) data;
+}
+
+char **Platform_getDynamicMeterChoices(Meter* meter) {
+   // TODO
+   (void) meter;
+   return NULL;
 }

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -467,3 +467,14 @@ void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size)
    (void) size;
    return;
 }
+
+char **Platform_getDiskUsageChoices(void) {
+   // TODO
+   return NULL;
+}
+
+void Platform_getDiskUsage(const char* choice, DiskUsageData *data) {
+   // TODO
+   (void) choice;
+   (void) data;
+}

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -361,8 +361,9 @@ bool Platform_getDiskIO(DiskIOData* data) {
    return false;
 }
 
-bool Platform_getNetworkIO(NetworkIOData* data) {
+bool Platform_getNetworkIO(const char* choice, NetworkIOData* data) {
    // TODO
+   (void) choice;
    (void)data;
    return false;
 }

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -441,3 +441,29 @@ void Platform_gettime_monotonic(uint64_t* msec) {
 #endif
 
 }
+
+char** Platform_getLocalIPv4addressChoices(void) {
+   // TODO
+   return NULL;
+}
+
+char** Platform_getLocalIPv6addressChoices(void) {
+   // TODO
+   return NULL;
+}
+
+void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size) {
+   // TODO
+   (void) choice;
+   (void) buffer;
+   (void) size;
+   return;
+}
+
+void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size) {
+   // TODO
+   (void) choice;
+   (void) buffer;
+   (void) size;
+   return;
+}

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -118,4 +118,9 @@ static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int ke
 
 static inline bool Platform_dynamicColumnWriteField(ATTR_UNUSED const Process* proc, ATTR_UNUSED RichString* str, ATTR_UNUSED unsigned int key) { return false; }
 
+char** Platform_getLocalIPv4addressChoices(void);
+char** Platform_getLocalIPv6addressChoices(void);
+void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
+void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
+
 #endif

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -15,6 +15,7 @@ in the source distribution for its full text.
 #include "BatteryMeter.h"
 #include "CPUMeter.h"
 #include "DiskIOMeter.h"
+#include "DiskUsageMeter.h"
 #include "Hashtable.h"
 #include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
@@ -122,5 +123,8 @@ char** Platform_getLocalIPv4addressChoices(void);
 char** Platform_getLocalIPv6addressChoices(void);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
+
+char **Platform_getDiskUsageChoices(void);
+void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
 
 #endif

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -75,7 +75,7 @@ FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);
 
-bool Platform_getNetworkIO(NetworkIOData* data);
+bool Platform_getNetworkIO(const char* choice, NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -119,12 +119,14 @@ static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int ke
 
 static inline bool Platform_dynamicColumnWriteField(ATTR_UNUSED const Process* proc, ATTR_UNUSED RichString* str, ATTR_UNUSED unsigned int key) { return false; }
 
-char** Platform_getLocalIPv4addressChoices(void);
-char** Platform_getLocalIPv6addressChoices(void);
+char** Platform_getLocalIPv4addressChoices(Meter* meter);
+char** Platform_getLocalIPv6addressChoices(Meter* meter);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
 
-char **Platform_getDiskUsageChoices(void);
+char **Platform_getDiskUsageChoices(Meter* meter);
 void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
+
+char **Platform_getDynamicMeterChoices(Meter* meter);
 
 #endif

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -268,13 +268,15 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
       *isOnAC = acline == 0 ? AC_ABSENT : AC_PRESENT;
 }
 
-char** Platform_getLocalIPv4addressChoices(void) {
+char** Platform_getLocalIPv4addressChoices(Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
-char** Platform_getLocalIPv6addressChoices(void) {
+char** Platform_getLocalIPv6addressChoices(Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
@@ -294,8 +296,9 @@ void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size)
    return;
 }
 
-char **Platform_getDiskUsageChoices(void) {
+char **Platform_getDiskUsageChoices(Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
@@ -303,4 +306,10 @@ void Platform_getDiskUsage(const char* choice, DiskUsageData *data) {
    // TODO
    (void) choice;
    (void) data;
+}
+
+char **Platform_getDynamicMeterChoices(Meter* meter) {
+   // TODO
+   (void) meter;
+   return NULL;
 }

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -266,3 +266,29 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
    else
       *isOnAC = acline == 0 ? AC_ABSENT : AC_PRESENT;
 }
+
+char** Platform_getLocalIPv4addressChoices(void) {
+   // TODO
+   return NULL;
+}
+
+char** Platform_getLocalIPv6addressChoices(void) {
+   // TODO
+   return NULL;
+}
+
+void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size) {
+   // TODO
+   (void) choice;
+   (void) buffer;
+   (void) size;
+   return;
+}
+
+void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size) {
+   // TODO
+   (void) choice;
+   (void) buffer;
+   (void) size;
+   return;
+}

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -292,3 +292,14 @@ void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size)
    (void) size;
    return;
 }
+
+char **Platform_getDiskUsageChoices(void) {
+   // TODO
+   return NULL;
+}
+
+void Platform_getDiskUsage(const char* choice, DiskUsageData *data) {
+   // TODO
+   (void) choice;
+   (void) data;
+}

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -245,8 +245,9 @@ bool Platform_getDiskIO(DiskIOData* data) {
    return false;
 }
 
-bool Platform_getNetworkIO(NetworkIOData* data) {
+bool Platform_getNetworkIO(const char* choice, NetworkIOData* data) {
    // TODO
+   (void) choice;
    (void)data;
    return false;
 }

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -111,4 +111,9 @@ static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int ke
 
 static inline bool Platform_dynamicColumnWriteField(ATTR_UNUSED const Process* proc, ATTR_UNUSED RichString* str, ATTR_UNUSED unsigned int key) { return false; }
 
+char** Platform_getLocalIPv4addressChoices(void);
+char** Platform_getLocalIPv6addressChoices(void);
+void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
+void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
+
 #endif

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -112,12 +112,14 @@ static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int ke
 
 static inline bool Platform_dynamicColumnWriteField(ATTR_UNUSED const Process* proc, ATTR_UNUSED RichString* str, ATTR_UNUSED unsigned int key) { return false; }
 
-char** Platform_getLocalIPv4addressChoices(void);
-char** Platform_getLocalIPv6addressChoices(void);
+char** Platform_getLocalIPv4addressChoices(Meter* meter);
+char** Platform_getLocalIPv6addressChoices(Meter* meter);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
 
-char **Platform_getDiskUsageChoices(void);
+char **Platform_getDiskUsageChoices(Meter* meter);
 void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
+
+char **Platform_getDynamicMeterChoices(Meter* meter);
 
 #endif

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -66,7 +66,7 @@ FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);
 
-bool Platform_getNetworkIO(NetworkIOData* data);
+bool Platform_getNetworkIO(const char* choice, NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -16,6 +16,7 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
+#include "DiskUsageMeter.h"
 #include "Hashtable.h"
 #include "Macros.h"
 #include "Meter.h"
@@ -115,5 +116,8 @@ char** Platform_getLocalIPv4addressChoices(void);
 char** Platform_getLocalIPv6addressChoices(void);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
+
+char **Platform_getDiskUsageChoices(void);
+void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
 
 #endif

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -408,7 +408,7 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
       *isOnAC = acline == 0 ? AC_ABSENT : AC_PRESENT;
 }
 
-char** Platform_getLocalIPv4addressChoices(void) {
+char** Platform_getLocalIPv4addressChoices(ATTR_UNUSED Meter* meter) {
    struct ifaddrs* ifp;
    int r = getifaddrs(&ifp);
    if (r < 0)
@@ -441,7 +441,7 @@ char** Platform_getLocalIPv4addressChoices(void) {
    return ret;
 }
 
-char** Platform_getLocalIPv6addressChoices(void) {
+char** Platform_getLocalIPv6addressChoices(ATTR_UNUSED Meter* meter) {
    struct ifaddrs* ifp;
    int r = getifaddrs(&ifp);
    if (r < 0)
@@ -530,7 +530,7 @@ void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size)
    return;
 }
 
-char **Platform_getDiskUsageChoices(void) {
+char **Platform_getDiskUsageChoices(ATTR_UNUSED Meter* meter) {
    unsigned int count = 0;
    struct statfs* mntbufp;
    int r = getmntinfo(&mntbufp, MNT_WAIT);
@@ -572,4 +572,10 @@ void Platform_getDiskUsage(const char* choice, DiskUsageData *data) {
    double available = (double)info.f_bfree * info.f_bsize;
    data->used = data->total - available;
    data->usedPercentage = 100.0 * (data->used / data->total);
+}
+
+char **Platform_getDynamicMeterChoices(Meter* meter) {
+   // TODO
+   (void) meter;
+   return NULL;
 }

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -13,6 +13,7 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
+#include "DiskUsageMeter.h"
 #include "Hashtable.h"
 #include "Meter.h"
 #include "NetworkIOMeter.h"
@@ -115,5 +116,8 @@ char** Platform_getLocalIPv4addressChoices(void);
 char** Platform_getLocalIPv6addressChoices(void);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
+
+char **Platform_getDiskUsageChoices(void);
+void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
 
 #endif

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -66,7 +66,7 @@ FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);
 
-bool Platform_getNetworkIO(NetworkIOData* data);
+bool Platform_getNetworkIO(const char* choice, NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -111,4 +111,9 @@ static inline void Platform_dynamicColumnsDone(ATTR_UNUSED Hashtable* table) { }
 
 static inline bool Platform_dynamicColumnWriteField(ATTR_UNUSED const Process* proc, ATTR_UNUSED RichString* str, ATTR_UNUSED unsigned int key) { return false; }
 
+char** Platform_getLocalIPv4addressChoices(void);
+char** Platform_getLocalIPv6addressChoices(void);
+void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
+void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
+
 #endif

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -112,12 +112,14 @@ static inline void Platform_dynamicColumnsDone(ATTR_UNUSED Hashtable* table) { }
 
 static inline bool Platform_dynamicColumnWriteField(ATTR_UNUSED const Process* proc, ATTR_UNUSED RichString* str, ATTR_UNUSED unsigned int key) { return false; }
 
-char** Platform_getLocalIPv4addressChoices(void);
-char** Platform_getLocalIPv6addressChoices(void);
+char** Platform_getLocalIPv4addressChoices(Meter* meter);
+char** Platform_getLocalIPv6addressChoices(Meter* meter);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
 
-char **Platform_getDiskUsageChoices(void);
+char **Platform_getDiskUsageChoices(Meter* meter);
 void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
+
+char **Platform_getDynamicMeterChoices(Meter* meter);
 
 #endif

--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -313,7 +313,7 @@ static char** LibSensors_getChoices(sensors_feature_type type, sensors_subfeatur
    return ret;
 }
 
-char** LibSensors_getTempChoices(void) {
+char** LibSensors_getTempChoices(ATTR_UNUSED Meter* meter) {
    return LibSensors_getChoices(SENSORS_FEATURE_TEMP, SENSORS_SUBFEATURE_TEMP_INPUT);
 }
 
@@ -377,7 +377,7 @@ void LibSensors_getTemp(const char* choice, double* currTemp, double* maxTemp) {
    return;
 }
 
-char** LibSensors_getFanChoices(void) {
+char** LibSensors_getFanChoices(ATTR_UNUSED Meter* meter) {
    return LibSensors_getChoices(SENSORS_FEATURE_FAN, SENSORS_SUBFEATURE_FAN_INPUT);
 }
 

--- a/linux/LibSensors.h
+++ b/linux/LibSensors.h
@@ -10,4 +10,7 @@ int LibSensors_reload(void);
 
 void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, unsigned int activeCPUs);
 
+char** LibSensors_getTempChoices(void);
+void LibSensors_getTemp(const char* choice, double* currTemp, double* maxTemp);
+
 #endif /* HEADER_LibSensors */

--- a/linux/LibSensors.h
+++ b/linux/LibSensors.h
@@ -1,6 +1,8 @@
 #ifndef HEADER_LibSensors
 #define HEADER_LibSensors
 
+#include "Meter.h"
+
 #include "linux/LinuxProcessList.h"
 
 
@@ -10,10 +12,10 @@ int LibSensors_reload(void);
 
 void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, unsigned int activeCPUs);
 
-char** LibSensors_getTempChoices(void);
+char** LibSensors_getTempChoices(ATTR_UNUSED Meter* meter);
 void LibSensors_getTemp(const char* choice, double* currTemp, double* maxTemp);
 
-char** LibSensors_getFanChoices(void);
+char** LibSensors_getFanChoices(ATTR_UNUSED Meter* meter);
 void LibSensors_getFan(const char* choice, double* curr, double* min, double* max);
 
 #endif /* HEADER_LibSensors */

--- a/linux/LibSensors.h
+++ b/linux/LibSensors.h
@@ -13,4 +13,7 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
 char** LibSensors_getTempChoices(void);
 void LibSensors_getTemp(const char* choice, double* currTemp, double* maxTemp);
 
+char** LibSensors_getFanChoices(void);
+void LibSensors_getFan(const char* choice, double* curr, double* min, double* max);
+
 #endif /* HEADER_LibSensors */

--- a/linux/LibSensorsFanMeter.c
+++ b/linux/LibSensorsFanMeter.c
@@ -1,0 +1,99 @@
+/*
+htop - LibSensorsFanMeter.c
+(C) 2021 htop dev team
+Released under the GNU GPL, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "LibSensorsFanMeter.h"
+
+#ifdef HAVE_SENSORS_SENSORS_H
+
+#include <math.h>
+
+#include "CRT.h"
+#include "linux/LibSensors.h"
+
+
+static const int LibSensorsFanMeter_attributes[] = {
+   METER_VALUE,
+};
+
+static void LibSensorsFanMeter_updateValues(Meter* this) {
+   if (!this->curChoice) {
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "N/A");
+      return;
+   }
+
+   LibSensors_getFan(this->curChoice, &this->values[0], &this->values[1], &this->total);
+
+   if (isnan(this->values[0]))
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%s - N/A", this->curChoice);
+   else
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%s - %d",
+                this->curChoice,
+                (int)this->values[0]);
+
+   /* Only fill bar with current value and only if total is available */
+   this->curItems = isnan(this->total) ? 0 : 1;
+}
+
+static void LibSensorsFanMeter_display(const Object* cast, RichString* out) {
+   const Meter* this = (const Meter*) cast;
+
+   if (!this->curChoice) {
+      RichString_appendAscii(out, CRT_colors[METER_VALUE_ERROR], "Invalid choice");
+      return;
+   } else if (isnan(this->values[0])) {
+      RichString_appendAscii(out, CRT_colors[METER_VALUE_ERROR], "Invalid data for ");
+      RichString_appendAscii(out, CRT_colors[METER_VALUE_ERROR], this->curChoice);
+      return;
+   }
+
+   char buffer[16];
+   int len;
+
+   len = RichString_appendAscii(out, CRT_colors[METER_VALUE], this->curChoice);
+   if (len < 15)
+      RichString_appendChr(out, CRT_colors[METER_TEXT], ' ', 15 - len);
+
+   len = xSnprintf(buffer, sizeof(buffer), " %.0f", this->values[0]);
+   RichString_appendnAscii(out, CRT_colors[METER_VALUE], buffer, len);
+
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], "  min: ");
+
+   if (isnan(this->values[1])) {
+      RichString_appendAscii(out, CRT_colors[METER_VALUE], "N/A");
+   } else {
+      len = xSnprintf(buffer, sizeof(buffer), "%.0f", this->values[1]);
+      RichString_appendnAscii(out, CRT_colors[METER_VALUE], buffer, len);
+   }
+
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], "  max: ");
+
+   if (isnan(this->total)) {
+      RichString_appendAscii(out, CRT_colors[METER_VALUE], "N/A");
+   } else {
+      len = xSnprintf(buffer, sizeof(buffer), "%.0f", this->total);
+      RichString_appendnAscii(out, CRT_colors[METER_VALUE], buffer, len);
+   }
+}
+
+const MeterClass LibSensorsFanMeter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete,
+      .display = LibSensorsFanMeter_display
+   },
+   .updateValues = LibSensorsFanMeter_updateValues,
+   .defaultMode = TEXT_METERMODE,
+   .maxItems = 2,
+   .total = 100.0,
+   .attributes = LibSensorsFanMeter_attributes,
+   .name = "SensorFan",
+   .uiName = "Sensor Fan Speed",
+   .caption = "Fan: ",
+   .getChoices = LibSensors_getFanChoices,
+};
+
+#endif /* HAVE_SENSORS_SENSORS_H */

--- a/linux/LibSensorsFanMeter.h
+++ b/linux/LibSensorsFanMeter.h
@@ -1,0 +1,16 @@
+#ifndef HEADER_LibSensorsFanMeter
+#define HEADER_LibSensorsFanMeter
+/*
+htop - LibSensorsFanMeter.h
+(C) 2021 htop dev team
+Released under the GNU GPL, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "Meter.h"
+
+#ifdef HAVE_SENSORS_SENSORS_H
+extern const MeterClass LibSensorsFanMeter_class;
+#endif
+
+#endif /* HEADER_LibSensorsFanMeter */

--- a/linux/LibSensorsTempMeter.c
+++ b/linux/LibSensorsTempMeter.c
@@ -1,0 +1,107 @@
+/*
+htop - LibSensorsTempMeter.c
+(C) 2021 htop dev team
+Released under the GNU GPL, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "LibSensorsTempMeter.h"
+
+#ifdef HAVE_SENSORS_SENSORS_H
+
+#include <math.h>
+
+#include "CRT.h"
+#include "linux/LibSensors.h"
+
+
+static const int LibSensorsTempMeter_attributes[] = {
+   METER_VALUE,
+};
+
+static void LibSensorsTempMeter_updateValues(Meter* this) {
+   const Settings* settings = this->pl->settings;
+
+   if (!this->curChoice) {
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "N/A");
+      return;
+   }
+
+   LibSensors_getTemp(this->curChoice, &this->values[0], &this->total);
+
+   if (isnan(this->values[0]))
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%s - N/A", this->curChoice);
+   else if (settings->degreeFahrenheit)
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%s - %d%sF",
+                this->curChoice,
+                (int)(this->values[0] * 9 / 5 + 32),
+                CRT_degreeSign);
+   else
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%s - %d%sC",
+                this->curChoice,
+                (int)this->values[0],
+                CRT_degreeSign);
+
+   /* Only fill bar if total is available */
+   this->curItems = isnan(this->total) ? 0 : 1;
+}
+
+static void LibSensorsTempMeter_display(const Object* cast, RichString* out) {
+   const Meter* this = (const Meter*) cast;
+   const Settings* settings = this->pl->settings;
+
+   if (!this->curChoice) {
+      RichString_appendAscii(out, CRT_colors[METER_VALUE_ERROR], "Invalid choice");
+      return;
+   } else if (isnan(this->values[0])) {
+      RichString_appendAscii(out, CRT_colors[METER_VALUE_ERROR], "Invalid data for ");
+      RichString_appendAscii(out, CRT_colors[METER_VALUE_ERROR], this->curChoice);
+      return;
+   }
+
+   char buffer[32], buffer2[16];
+   int len, len2;
+
+   len = RichString_appendAscii(out, CRT_colors[METER_VALUE], this->curChoice);
+   if (len < 15)
+      RichString_appendChr(out, CRT_colors[METER_TEXT], ' ', 15 - len);
+
+   if (settings->degreeFahrenheit)
+      len = xSnprintf(buffer, sizeof(buffer), " %d%sF",
+                      (int)(this->values[0] * 9 / 5 + 32),
+                      CRT_degreeSign);
+   else
+      len = xSnprintf(buffer, sizeof(buffer), " %d%sC",
+                      (int)this->values[0],
+                      CRT_degreeSign);
+   RichString_appendnWide(out, CRT_colors[METER_VALUE], buffer, len);
+
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], "  max: ");
+
+   if (isnan(this->total))
+      len2 = xSnprintf(buffer2, sizeof(buffer2), "N/A");
+   else if (settings->degreeFahrenheit)
+      len2 = xSnprintf(buffer2, sizeof(buffer2), "%d%sF", (int)(this->total * 9 / 5 + 32), CRT_degreeSign);
+   else
+      len2 = xSnprintf(buffer2, sizeof(buffer2), "%d%sC", (int)this->total, CRT_degreeSign);
+   RichString_appendnWide(out, CRT_colors[METER_VALUE], buffer2, len2);
+}
+
+const MeterClass LibSensorsTempMeter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete,
+      .display = LibSensorsTempMeter_display
+   },
+   .updateValues = LibSensorsTempMeter_updateValues,
+   .defaultMode = TEXT_METERMODE,
+   .maxItems = 1,
+   .total = 100.0,
+   .attributes = LibSensorsTempMeter_attributes,
+   .name = "SensorTemp",
+   .uiName = "Sensor Temperature",
+   .caption = "Temp: ",
+   .getChoices = LibSensors_getTempChoices,
+};
+
+#endif /* HAVE_SENSORS_SENSORS_H */

--- a/linux/LibSensorsTempMeter.h
+++ b/linux/LibSensorsTempMeter.h
@@ -1,0 +1,16 @@
+#ifndef HEADER_LibSensorsTempMeter
+#define HEADER_LibSensorsTempMeter
+/*
+htop - LibSensorsTempMeter.h
+(C) 2021 htop dev team
+Released under the GNU GPL, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "Meter.h"
+
+#ifdef HAVE_SENSORS_SENSORS_H
+extern const MeterClass LibSensorsTempMeter_class;
+#endif
+
+#endif /* HEADER_LibSensorsTempMeter */

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -74,6 +74,7 @@ in the source distribution for its full text.
 
 #ifdef HAVE_SENSORS_SENSORS_H
 #include "linux/LibSensors.h"
+#include "linux/LibSensorsFanMeter.h"
 #include "linux/LibSensorsTempMeter.h"
 #endif
 
@@ -257,6 +258,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &NetworkIOMeter_class,
    &NetworkInterfaceIOMeter_class,
 #ifdef HAVE_SENSORS_SENSORS_H
+   &LibSensorsFanMeter_class,
    &LibSensorsTempMeter_class,
 #endif
    &SELinuxMeter_class,

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -73,7 +73,8 @@ in the source distribution for its full text.
 #endif
 
 #ifdef HAVE_SENSORS_SENSORS_H
-#include "LibSensors.h"
+#include "linux/LibSensors.h"
+#include "linux/LibSensorsTempMeter.h"
 #endif
 
 #ifndef O_PATH
@@ -255,6 +256,9 @@ const MeterClass* const Platform_meterTypes[] = {
    &DiskUsageMeter_class,
    &NetworkIOMeter_class,
    &NetworkInterfaceIOMeter_class,
+#ifdef HAVE_SENSORS_SENSORS_H
+   &LibSensorsTempMeter_class,
+#endif
    &SELinuxMeter_class,
    &SystemdMeter_class,
    NULL

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -1087,7 +1087,7 @@ void Platform_done(void) {
 #endif
 }
 
-char** Platform_getLocalIPv4addressChoices(void) {
+char** Platform_getLocalIPv4addressChoices(ATTR_UNUSED Meter* meter) {
    int s = socket(AF_INET, SOCK_STREAM, 0);
    if (s < 0)
       return NULL;
@@ -1160,7 +1160,7 @@ void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size)
    xSnprintf(buffer, size, "N/A");
 }
 
-char** Platform_getLocalIPv6addressChoices(void) {
+char** Platform_getLocalIPv6addressChoices(ATTR_UNUSED Meter* meter) {
    FILE* file = fopen(PROCDIR "/net/if_inet6", "r");
    if (!file)
       return NULL;
@@ -1260,7 +1260,7 @@ static bool isFilesystemOfInterest(const char* fsname) {
    return false;
 }
 
-char **Platform_getDiskUsageChoices(void) {
+char **Platform_getDiskUsageChoices(ATTR_UNUSED Meter* meter) {
    FILE* mntFile = setmntent(PROCDIR "/mounts", "r");
    if (!mntFile)
       return NULL;
@@ -1290,4 +1290,10 @@ char **Platform_getDiskUsageChoices(void) {
    ret[count] = NULL;
 
    return ret;
+}
+
+char **Platform_getDynamicMeterChoices(Meter* meter) {
+   // TODO
+   (void) meter;
+   return NULL;
 }

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -133,12 +133,14 @@ static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int ke
 
 static inline bool Platform_dynamicColumnWriteField(ATTR_UNUSED const Process* proc, ATTR_UNUSED RichString* str, ATTR_UNUSED unsigned int key) { return false; }
 
-char** Platform_getLocalIPv4addressChoices(void);
-char** Platform_getLocalIPv6addressChoices(void);
+char** Platform_getLocalIPv4addressChoices(Meter* meter);
+char** Platform_getLocalIPv6addressChoices(Meter* meter);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
 
-char **Platform_getDiskUsageChoices(void);
+char **Platform_getDiskUsageChoices(Meter* meter);
 void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
+
+char **Platform_getDynamicMeterChoices(Meter* meter);
 
 #endif

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -132,4 +132,9 @@ static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int ke
 
 static inline bool Platform_dynamicColumnWriteField(ATTR_UNUSED const Process* proc, ATTR_UNUSED RichString* str, ATTR_UNUSED unsigned int key) { return false; }
 
+char** Platform_getLocalIPv4addressChoices(void);
+char** Platform_getLocalIPv6addressChoices(void);
+void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
+void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
+
 #endif

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -84,7 +84,7 @@ void Platform_getPressureStall(const char* file, bool some, double* ten, double*
 
 bool Platform_getDiskIO(DiskIOData* data);
 
-bool Platform_getNetworkIO(NetworkIOData* data);
+bool Platform_getNetworkIO(const char* choice, NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -19,6 +19,7 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
+#include "DiskUsageMeter.h"
 #include "Hashtable.h"
 #include "Macros.h"
 #include "Meter.h"
@@ -136,5 +137,8 @@ char** Platform_getLocalIPv4addressChoices(void);
 char** Platform_getLocalIPv6addressChoices(void);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
+
+char **Platform_getDiskUsageChoices(void);
+void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
 
 #endif

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -518,13 +518,15 @@ error:
       close(fd);
 }
 
-char** Platform_getLocalIPv4addressChoices(void) {
+char** Platform_getLocalIPv4addressChoices(Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
-char** Platform_getLocalIPv6addressChoices(void) {
+char** Platform_getLocalIPv6addressChoices(Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
@@ -544,8 +546,9 @@ void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size)
    return;
 }
 
-char **Platform_getDiskUsageChoices(void) {
+char **Platform_getDiskUsageChoices(Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
@@ -553,4 +556,10 @@ void Platform_getDiskUsage(const char* choice, DiskUsageData *data) {
    // TODO
    (void) choice;
    (void) data;
+}
+
+char **Platform_getDynamicMeterChoices(Meter* meter) {
+   // TODO
+   (void) meter;
+   return NULL;
 }

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -513,3 +513,29 @@ error:
    if (fd != -1)
       close(fd);
 }
+
+char** Platform_getLocalIPv4addressChoices(void) {
+   // TODO
+   return NULL;
+}
+
+char** Platform_getLocalIPv6addressChoices(void) {
+   // TODO
+   return NULL;
+}
+
+void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size) {
+   // TODO
+   (void) choice;
+   (void) buffer;
+   (void) size;
+   return;
+}
+
+void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size) {
+   // TODO
+   (void) choice;
+   (void) buffer;
+   (void) size;
+   return;
+}

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -400,8 +400,12 @@ bool Platform_getDiskIO(DiskIOData* data) {
    return true;
 }
 
-bool Platform_getNetworkIO(NetworkIOData* data) {
+bool Platform_getNetworkIO(const char* choice, NetworkIOData* data) {
    struct ifaddrs* ifaddrs = NULL;
+
+   // TODO: choice support
+   assert(!choice);
+   (void) choice;
 
    if (getifaddrs(&ifaddrs) != 0)
       return false;

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -539,3 +539,14 @@ void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size)
    (void) size;
    return;
 }
+
+char **Platform_getDiskUsageChoices(void) {
+   // TODO
+   return NULL;
+}
+
+void Platform_getDiskUsage(const char* choice, DiskUsageData *data) {
+   // TODO
+   (void) choice;
+   (void) data;
+}

--- a/netbsd/Platform.h
+++ b/netbsd/Platform.h
@@ -115,12 +115,14 @@ static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int ke
 
 static inline bool Platform_dynamicColumnWriteField(ATTR_UNUSED const Process* proc, ATTR_UNUSED RichString* str, ATTR_UNUSED unsigned int key) { return false; }
 
-char** Platform_getLocalIPv4addressChoices(void);
-char** Platform_getLocalIPv6addressChoices(void);
+char** Platform_getLocalIPv4addressChoices(Meter* meter);
+char** Platform_getLocalIPv6addressChoices(Meter* meter);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
 
-char **Platform_getDiskUsageChoices(void);
+char **Platform_getDiskUsageChoices(Meter* meter);
 void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
+
+char **Platform_getDynamicMeterChoices(Meter* meter);
 
 #endif

--- a/netbsd/Platform.h
+++ b/netbsd/Platform.h
@@ -115,4 +115,9 @@ static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int ke
 
 static inline bool Platform_dynamicColumnWriteField(ATTR_UNUSED const Process* proc, ATTR_UNUSED RichString* str, ATTR_UNUSED unsigned int key) { return false; }
 
+char** Platform_getLocalIPv4addressChoices(void);
+char** Platform_getLocalIPv6addressChoices(void);
+void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
+void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
+
 #endif

--- a/netbsd/Platform.h
+++ b/netbsd/Platform.h
@@ -71,7 +71,7 @@ FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);
 
-bool Platform_getNetworkIO(NetworkIOData* data);
+bool Platform_getNetworkIO(const char* choice, NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 

--- a/netbsd/Platform.h
+++ b/netbsd/Platform.h
@@ -120,4 +120,7 @@ char** Platform_getLocalIPv6addressChoices(void);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
 
+char **Platform_getDiskUsageChoices(void);
+void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
+
 #endif

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -377,13 +377,15 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
    }
 }
 
-char** Platform_getLocalIPv4addressChoices(void) {
+char** Platform_getLocalIPv4addressChoices(Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
-char** Platform_getLocalIPv6addressChoices(void) {
+char** Platform_getLocalIPv6addressChoices(Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
@@ -403,8 +405,9 @@ void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size)
    return;
 }
 
-char **Platform_getDiskUsageChoices(void) {
+char **Platform_getDiskUsageChoices(Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
@@ -412,4 +415,10 @@ void Platform_getDiskUsage(const char* choice, DiskUsageData *data) {
    // TODO
    (void) choice;
    (void) data;
+}
+
+char **Platform_getDynamicMeterChoices(Meter* meter) {
+   // TODO
+   (void) meter;
+   return NULL;
 }

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -375,3 +375,29 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
          *isOnAC = s.value;
    }
 }
+
+char** Platform_getLocalIPv4addressChoices(void) {
+   // TODO
+   return NULL;
+}
+
+char** Platform_getLocalIPv6addressChoices(void) {
+   // TODO
+   return NULL;
+}
+
+void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size) {
+   // TODO
+   (void) choice;
+   (void) buffer;
+   (void) size;
+   return;
+}
+
+void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size) {
+   // TODO
+   (void) choice;
+   (void) buffer;
+   (void) size;
+   return;
+}

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -313,8 +313,9 @@ bool Platform_getDiskIO(DiskIOData* data) {
    return false;
 }
 
-bool Platform_getNetworkIO(NetworkIOData* data) {
+bool Platform_getNetworkIO(const char* choice, NetworkIOData* data) {
    // TODO
+   (void) choice;
    (void)data;
    return false;
 }

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -401,3 +401,14 @@ void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size)
    (void) size;
    return;
 }
+
+char **Platform_getDiskUsageChoices(void) {
+   // TODO
+   return NULL;
+}
+
+void Platform_getDiskUsage(const char* choice, DiskUsageData *data) {
+   // TODO
+   (void) choice;
+   (void) data;
+}

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -14,6 +14,7 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
+#include "DiskUsageMeter.h"
 #include "Hashtable.h"
 #include "Meter.h"
 #include "NetworkIOMeter.h"
@@ -113,5 +114,8 @@ char** Platform_getLocalIPv4addressChoices(void);
 char** Platform_getLocalIPv6addressChoices(void);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
+
+char **Platform_getDiskUsageChoices(void);
+void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
 
 #endif

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -110,12 +110,14 @@ static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int ke
 
 static inline bool Platform_dynamicColumnWriteField(ATTR_UNUSED const Process* proc, ATTR_UNUSED RichString* str, ATTR_UNUSED unsigned int key) { return false; }
 
-char** Platform_getLocalIPv4addressChoices(void);
-char** Platform_getLocalIPv6addressChoices(void);
+char** Platform_getLocalIPv4addressChoices(Meter* meter);
+char** Platform_getLocalIPv6addressChoices(Meter* meter);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
 
-char **Platform_getDiskUsageChoices(void);
+char **Platform_getDiskUsageChoices(Meter* meter);
 void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
+
+char **Platform_getDynamicMeterChoices(Meter* meter);
 
 #endif

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -109,4 +109,9 @@ static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int ke
 
 static inline bool Platform_dynamicColumnWriteField(ATTR_UNUSED const Process* proc, ATTR_UNUSED RichString* str, ATTR_UNUSED unsigned int key) { return false; }
 
+char** Platform_getLocalIPv4addressChoices(void);
+char** Platform_getLocalIPv6addressChoices(void);
+void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
+void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
+
 #endif

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -64,7 +64,7 @@ FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);
 
-bool Platform_getNetworkIO(NetworkIOData* data);
+bool Platform_getNetworkIO(const char* choice, NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 

--- a/pcp/PCPDynamicMeter.c
+++ b/pcp/PCPDynamicMeter.c
@@ -68,6 +68,9 @@ static void PCPDynamicMeter_parseMetric(PCPDynamicMeters* meters, PCPDynamicMete
       /* lookup a dynamic metric with this name, else create */
       metric = PCPDynamicMeter_lookupMetric(meters, meter, key);
 
+      /* fill metric's indom */
+      metric->indom = PCPMetric_lookupInDom(value);
+
       /* use derived metrics in dynamic meters for simplicity */
       char* error;
       if (pmRegisterDerivedMetric(metric->name, value, &error) < 0) {
@@ -317,9 +320,17 @@ void PCPDynamicMeter_updateValues(PCPDynamicMeter* this, Meter* meter) {
       const pmDesc* desc = PCPMetric_desc(metric->id);
       pmAtomValue atom, raw;
 
-      if (!PCPMetric_values(metric->id, &raw, 1, desc->type)) {
-         bytes--; /* clear the separator */
-         continue;
+      if (!meter->curChoice) {
+         if (!PCPMetric_values(metric->id, &raw, 1, desc->type)) {
+            bytes--; /* clear the separator */
+            continue;
+         }
+      } else {
+         int internalId = pmLookupInDom(metric->indom, meter->curChoice);
+         if (!PCPMetric_instance(metric->id, internalId, internalId, &raw, desc->type)) {
+            bytes--; /* clear the separator */
+            continue;
+         }
       }
 
       pmUnits conv = desc->units;  /* convert to canonical units */
@@ -389,8 +400,15 @@ void PCPDynamicMeter_display(PCPDynamicMeter* this, ATTR_UNUSED const Meter* met
       pmAtomValue atom, raw;
       char buffer[64];
 
-      if (!PCPMetric_values(metric->id, &raw, 1, desc->type))
-         continue;
+      if (!meter->curChoice) {
+         if (!PCPMetric_values(metric->id, &raw, 1, desc->type))
+            continue;
+      } else {
+         int internalId = pmLookupInDom(metric->indom, meter->curChoice);
+         if (!PCPMetric_instance(metric->id, internalId, internalId, &raw, desc->type)) {
+            continue;
+         }
+      }
 
       pmUnits conv = desc->units;  /* convert to canonical units */
       if (conv.dimSpace)
@@ -457,4 +475,26 @@ void PCPDynamicMeter_display(PCPDynamicMeter* this, ATTR_UNUSED const Meter* met
    }
    if (nodata)
       RichString_writeAscii(out, CRT_colors[METER_VALUE_ERROR], "no data");
+}
+
+char** PCPDynamicMeter_getChoices(PCPDynamicMeter* this) {
+   unsigned int indom = this->metrics->indom;
+   int count = 0;
+   int* in;
+   char** raw;
+
+   count = pmGetInDom(indom, &in, &raw);
+   if (count < 0)
+      return NULL;
+
+   char** ret = xCalloc(count+1, sizeof(char*));
+
+   for (int i = 0; i < count; i++)
+      ret[i] = xStrdup(raw[i]);
+   ret[count] = NULL;
+
+   free(raw);
+   free(in);
+
+   return ret;
 }

--- a/pcp/PCPDynamicMeter.h
+++ b/pcp/PCPDynamicMeter.h
@@ -16,7 +16,6 @@ typedef struct PCPDynamicMetric_ {
    char* name; /* derived metric name */
    char* label;
    char* suffix;
-   unsigned int indom;
 } PCPDynamicMetric;
 
 typedef struct PCPDynamicMeter_ {

--- a/pcp/PCPDynamicMeter.h
+++ b/pcp/PCPDynamicMeter.h
@@ -16,6 +16,7 @@ typedef struct PCPDynamicMetric_ {
    char* name; /* derived metric name */
    char* label;
    char* suffix;
+   unsigned int indom;
 } PCPDynamicMetric;
 
 typedef struct PCPDynamicMeter_ {
@@ -40,5 +41,7 @@ void PCPDynamicMeter_enable(PCPDynamicMeter* this);
 void PCPDynamicMeter_updateValues(PCPDynamicMeter* this, Meter* meter);
 
 void PCPDynamicMeter_display(PCPDynamicMeter* this, const Meter* meter, RichString* out);
+
+char** PCPDynamicMeter_getChoices(PCPDynamicMeter* this);
 
 #endif

--- a/pcp/PCPMetric.c
+++ b/pcp/PCPMetric.c
@@ -29,6 +29,10 @@ int PCPMetric_type(PCPMetric metric) {
    return pcp->descs[metric].type;
 }
 
+pmInDom PCPMetric_indom(PCPMetric metric) {
+   return pcp->descs[metric].indom;
+}
+
 pmAtomValue* PCPMetric_values(PCPMetric metric, pmAtomValue* atom, int count, int type) {
    if (pcp->result == NULL)
       return NULL;
@@ -177,22 +181,4 @@ bool PCPMetric_fetch(struct timeval* timestamp) {
    if (timestamp)
       *timestamp = pcp->result->timestamp;
    return true;
-}
-
-unsigned int PCPMetric_lookupInDom(const char* metric) {
-   pmID pmid;
-   pmDesc desc;
-   int sts;
-
-   sts = pmLookupName(1, &metric, &pmid);
-   if (sts < 0) {
-      return 0;
-   }
-
-   sts = pmLookupDesc(pmid, &desc);
-   if (sts < 0) {
-      return 0;
-   }
-
-   return desc.indom;
 }

--- a/pcp/PCPMetric.c
+++ b/pcp/PCPMetric.c
@@ -178,3 +178,21 @@ bool PCPMetric_fetch(struct timeval* timestamp) {
       *timestamp = pcp->result->timestamp;
    return true;
 }
+
+unsigned int PCPMetric_lookupInDom(const char* metric) {
+   pmID pmid;
+   pmDesc desc;
+   int sts;
+
+   sts = pmLookupName(1, &metric, &pmid);
+   if (sts < 0) {
+      return 0;
+   }
+
+   sts = pmLookupDesc(pmid, &desc);
+   if (sts < 0) {
+      return 0;
+   }
+
+   return desc.indom;
+}

--- a/pcp/PCPMetric.h
+++ b/pcp/PCPMetric.h
@@ -177,4 +177,6 @@ int PCPMetric_instanceOffset(PCPMetric metric, int inst);
 
 pmAtomValue* PCPMetric_instance(PCPMetric metric, int inst, int offset, pmAtomValue* atom, int type);
 
+unsigned int PCPMetric_lookupInDom(const char* metric);
+
 #endif

--- a/pcp/PCPMetric.h
+++ b/pcp/PCPMetric.h
@@ -171,12 +171,12 @@ const pmDesc* PCPMetric_desc(PCPMetric metric);
 
 int PCPMetric_type(PCPMetric metric);
 
+pmInDom PCPMetric_indom(PCPMetric metric);
+
 int PCPMetric_instanceCount(PCPMetric metric);
 
 int PCPMetric_instanceOffset(PCPMetric metric, int inst);
 
 pmAtomValue* PCPMetric_instance(PCPMetric metric, int inst, int offset, pmAtomValue* atom, int type);
-
-unsigned int PCPMetric_lookupInDom(const char* metric);
 
 #endif

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -690,7 +690,10 @@ bool Platform_getDiskIO(DiskIOData* data) {
    return true;
 }
 
-bool Platform_getNetworkIO(NetworkIOData* data) {
+bool Platform_getNetworkIO(const char* choice, NetworkIOData* data) {
+   // TODO: choice support
+   assert(!choice); (void) choice;
+
    memset(data, 0, sizeof(*data));
 
    pmAtomValue value;

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -732,6 +732,16 @@ void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size)
    return;
 }
 
+char **Platform_getDiskUsageChoices() {
+   // TODO
+   return NULL;
+}
+
+void Platform_getDiskUsage(const char* choice, DiskUsageData *data) {
+   // TODO
+   (void) choice; (void) data;
+}
+
 void Platform_longOptionsUsage(ATTR_UNUSED const char* name) {
    printf(
 "   --host=HOSTSPEC              metrics source is PMCD at HOSTSPEC [see PCPIntro(1)]\n"

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -710,6 +710,28 @@ void Platform_getBattery(double* level, ACPresence* isOnAC) {
    *isOnAC = AC_ERROR;
 }
 
+char** Platform_getLocalIPv4addressChoices() {
+   // TODO
+   return NULL;
+}
+
+char** Platform_getLocalIPv6addressChoices() {
+   // TODO
+   return NULL;
+}
+
+void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size) {
+   // TODO
+   (void) choice; (void) buffer; (void) size;
+   return;
+}
+
+void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size) {
+   // TODO
+   (void) choice; (void) buffer; (void) size;
+   return;
+}
+
 void Platform_longOptionsUsage(ATTR_UNUSED const char* name) {
    printf(
 "   --host=HOSTSPEC              metrics source is PMCD at HOSTSPEC [see PCPIntro(1)]\n"

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -713,36 +713,44 @@ void Platform_getBattery(double* level, ACPresence* isOnAC) {
    *isOnAC = AC_ERROR;
 }
 
-char** Platform_getLocalIPv4addressChoices() {
+char** Platform_getLocalIPv4addressChoices(Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
-char** Platform_getLocalIPv6addressChoices() {
+char** Platform_getLocalIPv6addressChoices(Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size) {
    // TODO
-   (void) choice; (void) buffer; (void) size;
+   (void) choice;
+   (void) buffer;
+   (void) size;
    return;
 }
 
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size) {
    // TODO
-   (void) choice; (void) buffer; (void) size;
+   (void) choice;
+   (void) buffer;
+   (void) size;
    return;
 }
 
-char **Platform_getDiskUsageChoices() {
+char **Platform_getDiskUsageChoices(ATTR_UNUSED Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
 void Platform_getDiskUsage(const char* choice, DiskUsageData *data) {
    // TODO
-   (void) choice; (void) data;
+   (void) choice;
+   (void) data;
 }
 
 void Platform_longOptionsUsage(ATTR_UNUSED const char* name) {
@@ -856,4 +864,11 @@ bool Platform_dynamicColumnWriteField(const Process* proc, RichString* str, unsi
       return true;
    }
    return false;
+}
+
+char **Platform_getDynamicMeterChoices(Meter* meter) {
+   PCPDynamicMeter* this = Hashtable_get(pcp->meters.table, meter->param);
+   if (!this)
+      return NULL;
+   return PCPDynamicMeter_getChoices(this);
 }

--- a/pcp/Platform.h
+++ b/pcp/Platform.h
@@ -27,6 +27,7 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
+#include "DiskUsageMeter.h"
 #include "Hashtable.h"
 #include "Meter.h"
 #include "NetworkIOMeter.h"
@@ -159,5 +160,8 @@ char** Platform_getLocalIPv4addressChoices(void);
 char** Platform_getLocalIPv6addressChoices(void);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
+
+char **Platform_getDiskUsageChoices(void);
+void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
 
 #endif

--- a/pcp/Platform.h
+++ b/pcp/Platform.h
@@ -107,7 +107,7 @@ void Platform_getPressureStall(const char* file, bool some, double* ten, double*
 
 bool Platform_getDiskIO(DiskIOData* data);
 
-bool Platform_getNetworkIO(NetworkIOData* data);
+bool Platform_getNetworkIO(const char* choice, NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 

--- a/pcp/Platform.h
+++ b/pcp/Platform.h
@@ -156,12 +156,14 @@ const char* Platform_dynamicColumnInit(unsigned int key);
 
 bool Platform_dynamicColumnWriteField(const Process* proc, RichString* str, unsigned int key);
 
-char** Platform_getLocalIPv4addressChoices(void);
-char** Platform_getLocalIPv6addressChoices(void);
+char** Platform_getLocalIPv4addressChoices(Meter* meter);
+char** Platform_getLocalIPv6addressChoices(Meter* meter);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
 
-char **Platform_getDiskUsageChoices(void);
+char **Platform_getDiskUsageChoices(Meter* meter);
 void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
+
+char **Platform_getDynamicMeterChoices(Meter* meter);
 
 #endif

--- a/pcp/Platform.h
+++ b/pcp/Platform.h
@@ -155,4 +155,9 @@ const char* Platform_dynamicColumnInit(unsigned int key);
 
 bool Platform_dynamicColumnWriteField(const Process* proc, RichString* str, unsigned int key);
 
+char** Platform_getLocalIPv4addressChoices(void);
+char** Platform_getLocalIPv6addressChoices(void);
+void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
+void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
+
 #endif

--- a/pcp/meters/filesys
+++ b/pcp/meters/filesys
@@ -1,0 +1,12 @@
+#
+# pcp-htop(1) configuration file - see pcp-htop(5)
+#
+
+[filesys]
+caption = Filesys
+mountdir.metric = filesys.mountdir
+mountdir.color = green
+mountdir.label = dirs
+usedfiles.metric = filesys.usedfiles
+usedfiles.color = blue
+usedfiles.label = usedfiles

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -328,7 +328,7 @@ bool Platform_getDiskIO(DiskIOData* data) {
 bool Platform_getNetworkIO(const char* choice, NetworkIOData* data) {
    // TODO
    (void) choice;
-   (void)data;
+   (void) data;
    return false;
 }
 
@@ -337,13 +337,15 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
    *isOnAC = AC_ERROR;
 }
 
-char** Platform_getLocalIPv4addressChoices(void) {
+char** Platform_getLocalIPv4addressChoices(Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
-char** Platform_getLocalIPv6addressChoices(void) {
+char** Platform_getLocalIPv6addressChoices(Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
@@ -363,8 +365,9 @@ void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size)
    return;
 }
 
-char **Platform_getDiskUsageChoices(void) {
+char **Platform_getDiskUsageChoices(Meter* meter) {
    // TODO
+   (void) meter;
    return NULL;
 }
 
@@ -372,4 +375,10 @@ void Platform_getDiskUsage(const char* choice, DiskUsageData *data) {
    // TODO
    (void) choice;
    (void) data;
+}
+
+char **Platform_getDynamicMeterChoices(Meter* meter) {
+   // TODO
+   (void) meter;
+   return NULL;
 }

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -325,8 +325,9 @@ bool Platform_getDiskIO(DiskIOData* data) {
    return false;
 }
 
-bool Platform_getNetworkIO(NetworkIOData* data) {
+bool Platform_getNetworkIO(const char* choice, NetworkIOData* data) {
    // TODO
+   (void) choice;
    (void)data;
    return false;
 }

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -361,3 +361,14 @@ void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size)
    (void) size;
    return;
 }
+
+char **Platform_getDiskUsageChoices(void) {
+   // TODO
+   return NULL;
+}
+
+void Platform_getDiskUsage(const char* choice, DiskUsageData *data) {
+   // TODO
+   (void) choice;
+   (void) data;
+}

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -335,3 +335,29 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
    *percent = NAN;
    *isOnAC = AC_ERROR;
 }
+
+char** Platform_getLocalIPv4addressChoices(void) {
+   // TODO
+   return NULL;
+}
+
+char** Platform_getLocalIPv6addressChoices(void) {
+   // TODO
+   return NULL;
+}
+
+void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size) {
+   // TODO
+   (void) choice;
+   (void) buffer;
+   (void) size;
+   return;
+}
+
+void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size) {
+   // TODO
+   (void) choice;
+   (void) buffer;
+   (void) size;
+   return;
+}

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -151,12 +151,14 @@ static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int ke
 
 static inline bool Platform_dynamicColumnWriteField(ATTR_UNUSED const Process* proc, ATTR_UNUSED RichString* str, ATTR_UNUSED unsigned int key) { return false; }
 
-char** Platform_getLocalIPv4addressChoices(void);
-char** Platform_getLocalIPv6addressChoices(void);
+char** Platform_getLocalIPv4addressChoices(Meter* meter);
+char** Platform_getLocalIPv6addressChoices(Meter* meter);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
 
-char **Platform_getDiskUsageChoices(void);
+char **Platform_getDiskUsageChoices(Meter* meter);
 void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
+
+char **Platform_getDynamicMeterChoices(Meter* meter);
 
 #endif

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -31,6 +31,7 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
+#include "DiskUsageMeter.h"
 #include "Hashtable.h"
 #include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
@@ -154,5 +155,8 @@ char** Platform_getLocalIPv4addressChoices(void);
 char** Platform_getLocalIPv6addressChoices(void);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
+
+char **Platform_getDiskUsageChoices(void);
+void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
 
 #endif

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -93,7 +93,7 @@ FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);
 
-bool Platform_getNetworkIO(NetworkIOData* data);
+bool Platform_getNetworkIO(const char* choice, NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -150,4 +150,9 @@ static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int ke
 
 static inline bool Platform_dynamicColumnWriteField(ATTR_UNUSED const Process* proc, ATTR_UNUSED RichString* str, ATTR_UNUSED unsigned int key) { return false; }
 
+char** Platform_getLocalIPv4addressChoices(void);
+char** Platform_getLocalIPv6addressChoices(void);
+void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
+void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
+
 #endif

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -165,11 +165,13 @@ void Platform_getRelease(char** string) {
    *string = xStrdup(Platform_unsupported);
 }
 
-char** Platform_getLocalIPv4addressChoices(void) {
+char** Platform_getLocalIPv4addressChoices(Meter* meter) {
+   (void) meter;
    return NULL;
 }
 
-char** Platform_getLocalIPv6addressChoices(void) {
+char** Platform_getLocalIPv6addressChoices(Meter* meter) {
+   (void) meter;
    return NULL;
 }
 
@@ -187,11 +189,18 @@ void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size)
    return;
 }
 
-char **Platform_getDiskUsageChoices() {
+char **Platform_getDiskUsageChoices(Meter* meter) {
+   (void) meter;
    return NULL;
 }
 
 void Platform_getDiskUsage(const char* choice, DiskUsageData *data) {
    (void) choice;
    (void) data;
+}
+
+char **Platform_getDynamicMeterChoices(Meter* meter) {
+   // TODO
+   (void) meter;
+   return NULL;
 }

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -162,3 +162,25 @@ void Platform_getHostname(char* buffer, size_t size) {
 void Platform_getRelease(char** string) {
    *string = xStrdup(Platform_unsupported);
 }
+
+char** Platform_getLocalIPv4addressChoices(void) {
+   return NULL;
+}
+
+char** Platform_getLocalIPv6addressChoices(void) {
+   return NULL;
+}
+
+void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size) {
+   (void) choice;
+   (void) buffer; (void)
+   size;
+   return;
+}
+
+void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size) {
+   (void) choice;
+   (void) buffer;
+   (void) size;
+   return;
+}

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -184,3 +184,12 @@ void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size)
    (void) size;
    return;
 }
+
+char **Platform_getDiskUsageChoices() {
+   return NULL;
+}
+
+void Platform_getDiskUsage(const char* choice, DiskUsageData *data) {
+   (void) choice;
+   (void) data;
+}

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -145,7 +145,9 @@ bool Platform_getDiskIO(DiskIOData* data) {
    return false;
 }
 
-bool Platform_getNetworkIO(NetworkIOData* data) {
+bool Platform_getNetworkIO(const char* choice, NetworkIOData* data) {
+   // TODO
+   (void) choice;
    (void)data;
    return false;
 }

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -57,7 +57,7 @@ FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);
 
-bool Platform_getNetworkIO(NetworkIOData* data);
+bool Platform_getNetworkIO(const char* choice, NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -98,4 +98,9 @@ static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int ke
 
 static inline bool Platform_dynamicColumnWriteField(ATTR_UNUSED const Process* proc, ATTR_UNUSED RichString* str, ATTR_UNUSED unsigned int key) { return false; }
 
+char** Platform_getLocalIPv4addressChoices(void);
+char** Platform_getLocalIPv6addressChoices(void);
+void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
+void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
+
 #endif

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -11,6 +11,7 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
+#include "DiskUsageMeter.h"
 #include "Hashtable.h"
 #include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
@@ -102,5 +103,8 @@ char** Platform_getLocalIPv4addressChoices(void);
 char** Platform_getLocalIPv6addressChoices(void);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
+
+char **Platform_getDiskUsageChoices(void);
+void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
 
 #endif

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -99,12 +99,14 @@ static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int ke
 
 static inline bool Platform_dynamicColumnWriteField(ATTR_UNUSED const Process* proc, ATTR_UNUSED RichString* str, ATTR_UNUSED unsigned int key) { return false; }
 
-char** Platform_getLocalIPv4addressChoices(void);
-char** Platform_getLocalIPv6addressChoices(void);
+char** Platform_getLocalIPv4addressChoices(Meter* meter);
+char** Platform_getLocalIPv6addressChoices(Meter* meter);
 void Platform_getLocalIPv4address(const char* choice, char* buffer, size_t size);
 void Platform_getLocalIPv6address(const char* choice, char* buffer, size_t size);
 
-char **Platform_getDiskUsageChoices(void);
+char **Platform_getDiskUsageChoices(Meter* meter);
 void Platform_getDiskUsage(const char* choice, DiskUsageData *data);
+
+char **Platform_getDynamicMeterChoices(Meter* meter);
 
 #endif


### PR DESCRIPTION
Avoid duplicating metric name and descriptor lookups just
for Choice meters as these have already been performed as
part of initialization - use the cached values instead.